### PR TITLE
Bump chart and agent versions

### DIFF
--- a/regional/main.tf
+++ b/regional/main.tf
@@ -38,7 +38,7 @@ resource "helm_release" "datadog_operator" {
     file("${path.module}/helm/datadog-operator.yml")
   ]
 
-  version = "1.8.6"
+  version = "2.0.0"
 }
 
 # Kubernetes Namespace Resource

--- a/regional/manifests/variables.tf
+++ b/regional/manifests/variables.tf
@@ -168,7 +168,7 @@ variable "node_agent_log_level" {
 variable "node_agent_tag" {
   description = "Tag for the Datadog node agent image"
   type        = string
-  default     = "7.55.3"
+  default     = "7.56.0"
 }
 
 variable "node_agent_tolerations" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the Datadog operator to version 2.0.0, enhancing its integration with Kubernetes and introducing new capabilities.
	- Updated the default version of the Datadog node agent to 7.56.0, which may include new features and improvements.
  
- **Bug Fixes**
	- The new versions may resolve existing issues related to the previous operator and node agent versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->