### PR TITLE
Use cert-manager for CA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.95.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.253
+    rev: 3.2.255
     hooks:
       - id: checkov
         verbose: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Repository Description
 
-Terraform **example** module for the Datadog Kubernetes Operator.
+Terraform **example** module for the Datadog Kubernetes Operator on Google Kubernetes Engine (GKE).
 
 > [!NOTE]
 > We do not recommend consuming this module like you might a [public module](https://registry.terraform.io/browse/modules). It is a baseline, something you can fork, potentially maintain, and modify to fit your organization's needs. Using public modules vs. writing your own has various [drivers and trade-offs](https://docs.osinfra.io/fundamentals/architecture-decision-records/adr-0003) that your organization should evaluate.

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -4,7 +4,7 @@
 resource "helm_release" "datadog_operator" {
   chart      = "datadog-operator"
   name       = "datadog-operator"
-  namespace  = kubernetes_namespace_v1.datadog.metadata[0].name
+  namespace  = "datadog"
   repository = "https://helm.datadoghq.com"
 
   set {
@@ -71,22 +71,13 @@ resource "helm_release" "datadog_operator" {
   version = var.operator_version
 }
 
-# Kubernetes Namespace Resource
-# https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1
-
-resource "kubernetes_namespace_v1" "datadog" {
-  metadata {
-    name = "datadog"
-  }
-}
-
 # Kubernetes Secret Resource
 # https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1
 
 resource "kubernetes_secret_v1" "datadog_operator_secret" {
   metadata {
     name      = "datadog-operator-secret"
-    namespace = kubernetes_namespace_v1.datadog.metadata[0].name
+    namespace = "datadog"
   }
 
   data = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the README to clarify that the Terraform example module is specifically for the Datadog Kubernetes Operator on Google Kubernetes Engine (GKE).

- **Chores**
	- Changed the namespace for the Datadog Helm release and Kubernetes secret to a static value, indicating that the namespace is now assumed to exist rather than being created within the Terraform configuration.
	- Updated pre-commit hook repository versions for improved functionality and potential bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->