### PR TITLE
Update Datadog Node Agent to 7.62.1 and Operator to 2.6.0; bump pre-commit hooks versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ crash.log
 # be included in version control.
 local.tfvars
 
-# Ignore override files as they are usually used to override ressources locally
+# Ignore override files as they are usually used to override resources locally
 override.tf
 override.tf.json
 *_override.tf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.0
+    rev: v1.97.3
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.357
+    rev: 3.2.368
     hooks:
       - id: checkov
         verbose: true

--- a/regional/README.md
+++ b/regional/README.md
@@ -37,7 +37,7 @@ No requirements.
 | <a name="input_cluster_prefix"></a> [cluster\_prefix](#input\_cluster\_prefix) | Prefix for your cluster name, region, and zone (if applicable) will be added to the end of the cluster name | `string` | n/a | yes |
 | <a name="input_limits_cpu"></a> [limits\_cpu](#input\_limits\_cpu) | CPU limits for the Datadog Operator | `string` | `"200m"` | no |
 | <a name="input_limits_memory"></a> [limits\_memory](#input\_limits\_memory) | Memory limits for the Datadog Operator | `string` | `"64Mi"` | no |
-| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | The version of the Datadog Operator to install | `string` | `"2.5.1"` | no |
+| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | The version of the Datadog Operator to install | `string` | `"2.6.0"` | no |
 | <a name="input_requests_cpu"></a> [requests\_cpu](#input\_requests\_cpu) | CPU requests for the Datadog Operator | `string` | `"100m"` | no |
 | <a name="input_requests_memory"></a> [requests\_memory](#input\_requests\_memory) | Memory requests for the Datadog Operator | `string` | `"32Mi"` | no |
 | <a name="input_watch_namespaces"></a> [watch\_namespaces](#input\_watch\_namespaces) | Restricts the Operator to watch its managed resources on specific namespaces - set to [""] to watch all namespaces | `list(string)` | <pre>[<br/>  "datadog"<br/>]</pre> | no |

--- a/regional/manifests/README.md
+++ b/regional/manifests/README.md
@@ -62,7 +62,7 @@ No requirements.
 | <a name="input_node_agent_log_level"></a> [node\_agent\_log\_level](#input\_node\_agent\_log\_level) | Node Agent log level | `string` | `"info"` | no |
 | <a name="input_node_agent_requests_cpu"></a> [node\_agent\_requests\_cpu](#input\_node\_agent\_requests\_cpu) | CPU requests for the Datadog Node Agent | `string` | `"100m"` | no |
 | <a name="input_node_agent_requests_memory"></a> [node\_agent\_requests\_memory](#input\_node\_agent\_requests\_memory) | Memory requests for the Datadog Node Agent | `string` | `"128Mi"` | no |
-| <a name="input_node_agent_tag"></a> [node\_agent\_tag](#input\_node\_agent\_tag) | Tag for the Datadog node agent image | `string` | `"7.61.0"` | no |
+| <a name="input_node_agent_tag"></a> [node\_agent\_tag](#input\_node\_agent\_tag) | Tag for the Datadog node agent image | `string` | `"7.62.1"` | no |
 | <a name="input_node_agent_tolerations"></a> [node\_agent\_tolerations](#input\_node\_agent\_tolerations) | Tolerations for the Datadog node agent | <pre>list(object({<br/>    key      = string<br/>    operator = string<br/>    value    = string<br/>    effect   = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_registry"></a> [registry](#input\_registry) | Docker registry for the Datadog container images | `string` | n/a | yes |
 | <a name="input_team"></a> [team](#input\_team) | Team name to be used as a tag in Datadog | `string` | n/a | yes |

--- a/regional/manifests/variables.tf
+++ b/regional/manifests/variables.tf
@@ -204,7 +204,7 @@ variable "node_agent_requests_memory" {
 variable "node_agent_tag" {
   description = "Tag for the Datadog node agent image"
   type        = string
-  default     = "7.61.0"
+  default     = "7.62.1"
 }
 
 variable "node_agent_tolerations" {

--- a/regional/variables.tf
+++ b/regional/variables.tf
@@ -39,7 +39,7 @@ variable "limits_memory" {
 variable "operator_version" {
   description = "The version of the Datadog Operator to install"
   type        = string
-  default     = "2.5.1"
+  default     = "2.6.0"
 }
 
 variable "requests_cpu" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
	- Corrected a comment typo in the ignore configuration.
	- Updated dependency versions for pre-commit tools.
- Documentation
	- Revised Terraform documentation to reflect updated defaults:
		- Operator version changed from "2.5.1" to "2.6.0".
		- Node agent tag updated from "7.61.0" to "7.62.1".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->