### PR TITLE
Add full Datadog Agent feature support and update versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,28 @@
 # pt-arche-kubernetes-datadog-operator
 
 Deploys the Datadog Operator on GKE for cluster-level monitoring, APM, and log collection. Includes a `regional/` submodule for zone-specific configuration.
+
+## Datadog Pricing in Variable Descriptions
+
+Many variables in `regional/manifests/variables.tofu` include pricing from https://www.datadoghq.com/pricing/ to help operators understand the cost impact of enabling features.
+
+**Keep pricing current:** Datadog revises its pricing periodically. When modifying any `enable_*` variable or adding new feature variables:
+
+1. Verify the current price at https://www.datadoghq.com/pricing/ for the relevant product.
+2. Note both the **annual** and **on-demand** rates, and any prerequisite products (e.g. "requires Infrastructure Pro or Enterprise").
+3. Update the `description` in `variables.tofu` if the price or product name has changed.
+
+Pricing to verify when touching these variables:
+
+| Variable | Pricing page product |
+|---|---|
+| `enable_apm`, `enable_apm_instrumentation` | Application Performance Monitoring |
+| `enable_asm_threats`, `enable_asm_iast`, `enable_asm_sca` | App and API Protection |
+| `enable_cspm` | Cloud Security → CSM Pro |
+| `enable_cws`, `enable_cws_network_detection` | Workload Protection / CSM Enterprise |
+| `enable_npm` | Network Monitoring → Cloud Network Monitoring |
+| `enable_usm` | Universal Service Monitoring |
+| `enable_live_process_collection` | Infrastructure (Enterprise tier feature) |
+| `enable_log_collection`, `enable_container_collect_all` | Log Management |
+| `enable_prometheus_scrape` | Infrastructure → Custom Metrics |
+| `enable_sbom`, `enable_sbom_host`, `enable_sbom_enrichment_usage` | Cloud Security → CSM Pro/Enterprise |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,17 +2,58 @@
 
 Deploys the Datadog Operator on GKE for cluster-level monitoring, APM, and log collection. Includes a `regional/` submodule for zone-specific configuration.
 
+## Module Structure
+
+This repo contains two distinct OpenTofu modules — each has its own variables, providers, and state:
+
+| Directory | Purpose |
+|---|---|
+| `regional/` | Deploys the Datadog Operator Helm chart into the cluster |
+| `regional/manifests/` | Deploys the `DatadogAgent` CRD that configures the agent |
+
+All feature toggles (`enable_*`) live in `regional/manifests/variables.tofu` and are wired into `kubernetes_manifest.agent` in `regional/manifests/main.tofu`.
+
+## Version Locations
+
+Three version values must be kept in sync:
+
+| What | File | Variable |
+|---|---|---|
+| Datadog Operator Helm chart | `regional/variables.tofu` | `operator_version` |
+| Node Agent image tag | `regional/manifests/variables.tofu` | `node_agent_tag` |
+| Cluster Agent image tag | `regional/manifests/variables.tofu` | `cluster_agent_tag` |
+
+Finding latest versions:
+- Operator chart: https://github.com/DataDog/helm-charts/releases (filter `datadog-operator-*`)
+- Agent / Cluster Agent: https://hub.docker.com/r/datadog/agent/tags (both share the same version)
+- CRD spec reference: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+
+## Adding a New Agent Feature
+
+1. Add an `enable_*` variable to `regional/manifests/variables.tofu`. Include pricing if the feature has a cost (see *Datadog Pricing* section below).
+2. Add the feature block inside `spec.features` in `regional/manifests/main.tofu`.
+3. If the feature has a hard prerequisite on another feature, add a `check` block at the bottom of `main.tofu` and document it in the *Feature Dependency Rules* table below.
+4. If the new `check` block would fire with default values, update the test fixture at `tests/fixtures/default/regional/manifests/main.tofu`.
+
+## Feature Dependency Rules
+
+These cross-variable constraints are enforced via `check` blocks at the bottom of `regional/manifests/main.tofu`:
+
+| Dependent feature | Requires |
+|---|---|
+| `enable_apm_instrumentation` | `enable_apm = true` |
+| `enable_cws_network_detection` | `enable_cws = true` |
+| `enable_sbom_enrichment_usage` | `enable_sbom = true` |
+
+Keep this table and the `check` blocks in sync when adding new dependencies.
+
 ## Datadog Pricing in Variable Descriptions
 
-Many variables in `regional/manifests/variables.tofu` include pricing from https://www.datadoghq.com/pricing/ to help operators understand the cost impact of enabling features.
-
-**Keep pricing current:** Datadog revises its pricing periodically. When modifying any `enable_*` variable or adding new feature variables:
+Many variables in `regional/manifests/variables.tofu` include pricing from https://www.datadoghq.com/pricing/ to help operators understand cost impact. Datadog revises pricing periodically. When modifying or adding feature variables:
 
 1. Verify the current price at https://www.datadoghq.com/pricing/ for the relevant product.
-2. Note both the **annual** and **on-demand** rates, and any prerequisite products (e.g. "requires Infrastructure Pro or Enterprise").
-3. Update the `description` in `variables.tofu` if the price or product name has changed.
-
-Pricing to verify when touching these variables:
+2. Capture both the **annual** and **on-demand** rates, and any prerequisite products.
+3. Update the `description` if the price or product name has changed.
 
 | Variable | Pricing page product |
 |---|---|

--- a/regional/manifests/main.tofu
+++ b/regional/manifests/main.tofu
@@ -177,7 +177,7 @@ resource "kubernetes_manifest" "agent" {
       override = {
         clusterAgent = {
           containers = {
-            all = {
+            "cluster-agent" = {
               resources = {
                 limits = {
                   cpu    = var.cluster_agent_limits_cpu

--- a/regional/manifests/main.tofu
+++ b/regional/manifests/main.tofu
@@ -51,9 +51,17 @@ resource "kubernetes_manifest" "agent" {
         }
 
         autoscaling = {
-          workload = {
-            enabled = true
+          cluster = {
+            enabled = var.enable_autoscaling_cluster
           }
+
+          workload = {
+            enabled = var.enable_autoscaling_workload
+          }
+        }
+
+        clusterChecks = {
+          useClusterChecksRunners = var.enable_cluster_checks_runners
         }
 
         cspm = {
@@ -68,8 +76,20 @@ resource "kubernetes_manifest" "agent" {
           }
         }
 
+        ebpfCheck = {
+          enabled = var.enable_ebpf_check
+        }
+
         externalMetricsServer = {
           enabled = var.enable_external_metrics_server
+        }
+
+        helmCheck = {
+          enabled = var.enable_helm_check
+        }
+
+        liveProcessCollection = {
+          enabled = var.enable_live_process_collection
         }
 
         logCollection = {
@@ -81,8 +101,34 @@ resource "kubernetes_manifest" "agent" {
           enabled = var.enable_npm
         }
 
+        oomKill = {
+          enabled = var.enable_oom_kill
+        }
+
         orchestratorExplorer = {
           enabled = var.enable_orchestrator_explorer
+        }
+
+        otelCollector = {
+          enabled = var.enable_otel_collector
+        }
+
+        otlp = {
+          receiver = {
+            protocols = {
+              grpc = {
+                enabled = var.enable_otlp_grpc
+              }
+
+              http = {
+                enabled = var.enable_otlp_http
+              }
+            }
+          }
+        }
+
+        prometheusScrape = {
+          enabled = var.enable_prometheus_scrape
         }
 
         sbom = {
@@ -92,6 +138,24 @@ resource "kubernetes_manifest" "agent" {
           }
 
           enabled = var.enable_sbom
+
+          enrichment = {
+            usage = {
+              enabled = var.enable_sbom_enrichment_usage
+            }
+          }
+
+          host = {
+            enabled = var.enable_sbom_host
+          }
+        }
+
+        serviceDiscovery = {
+          enabled = var.enable_service_discovery
+        }
+
+        tcpQueueLength = {
+          enabled = var.enable_tcp_queue_length
         }
 
         usm = {
@@ -112,12 +176,32 @@ resource "kubernetes_manifest" "agent" {
 
       override = {
         clusterAgent = {
+          containers = {
+            all = {
+              resources = {
+                limits = {
+                  cpu    = var.cluster_agent_limits_cpu
+                  memory = var.cluster_agent_limits_memory
+                }
+
+                requests = {
+                  cpu    = var.cluster_agent_requests_cpu
+                  memory = var.cluster_agent_requests_memory
+                }
+              }
+            }
+          }
+
           env = local.cluster_agent_env_vars_merged
+
+          image = {
+            tag = var.cluster_agent_tag
+          }
 
           labels = {
             "tags.datadoghq.com/env"     = module.core_helpers.environment
             "tags.datadoghq.com/service" = "datadog-cluster-agent"
-            "tags.datadoghq.com/version" = var.node_agent_tag
+            "tags.datadoghq.com/version" = var.cluster_agent_tag
           }
         }
 
@@ -193,6 +277,27 @@ resource "kubernetes_manifest" "agent" {
         }
       }
     }
+  }
+}
+
+check "apm_instrumentation_requires_apm" {
+  assert {
+    condition     = !var.enable_apm_instrumentation || var.enable_apm
+    error_message = "enable_apm_instrumentation requires enable_apm to be true."
+  }
+}
+
+check "cws_network_requires_cws" {
+  assert {
+    condition     = !var.enable_cws_network_detection || var.enable_cws
+    error_message = "enable_cws_network_detection requires enable_cws to be true."
+  }
+}
+
+check "sbom_enrichment_requires_sbom" {
+  assert {
+    condition     = !var.enable_sbom_enrichment_usage || var.enable_sbom
+    error_message = "enable_sbom_enrichment_usage requires enable_sbom to be true."
   }
 }
 

--- a/regional/manifests/variables.tofu
+++ b/regional/manifests/variables.tofu
@@ -46,6 +46,12 @@ variable "cluster_agent_requests_memory" {
   default     = "128Mi"
 }
 
+variable "cluster_agent_tag" {
+  description = "Tag for the Datadog cluster agent image"
+  type        = string
+  default     = "7.78.1"
+}
+
 variable "cluster_prefix" {
   description = "Prefix for your cluster name, region, and zone (if applicable) will be added to the end of the cluster name"
   type        = string
@@ -87,6 +93,24 @@ variable "enable_asm_threats" {
   default     = false
 }
 
+variable "enable_autoscaling_cluster" {
+  description = "Enable cluster autoscaling product (requires Cluster Agent 7.74.0+)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_autoscaling_workload" {
+  description = "Enable workload autoscaling product"
+  type        = bool
+  default     = true
+}
+
+variable "enable_cluster_checks_runners" {
+  description = "Enable dedicated cluster checks runner pods to offload cluster-level checks from the cluster agent (recommended for large clusters)"
+  type        = bool
+  default     = false
+}
+
 variable "enable_container_collect_all" {
   description = "Enable log collection for all containers"
   type        = bool
@@ -117,14 +141,32 @@ variable "enable_cws_network_detection" {
   default     = false
 }
 
+variable "enable_ebpf_check" {
+  description = "Enable the eBPF check for kernel-level observability"
+  type        = bool
+  default     = false
+}
+
 variable "enable_external_metrics_server" {
   description = "Enable the External Metrics Server"
   type        = bool
   default     = true
 }
 
+variable "enable_helm_check" {
+  description = "Enable the Helm check to monitor Helm releases in the cluster"
+  type        = bool
+  default     = false
+}
+
 variable "enable_jmx" {
   description = "Whether the Agent image should support JMX"
+  type        = bool
+  default     = false
+}
+
+variable "enable_live_process_collection" {
+  description = "Enable live process monitoring (process details visible in Datadog)"
   type        = bool
   default     = false
 }
@@ -141,16 +183,70 @@ variable "enable_npm" {
   default     = true
 }
 
+variable "enable_oom_kill" {
+  description = "Enable the OOMKill eBPF-based check to track out-of-memory events"
+  type        = bool
+  default     = false
+}
+
 variable "enable_orchestrator_explorer" {
   description = "Enable Orchestrator Explorer"
   type        = bool
   default     = true
 }
 
+variable "enable_otel_collector" {
+  description = "Enable the embedded OpenTelemetry collector in the Agent"
+  type        = bool
+  default     = false
+}
+
+variable "enable_otlp_grpc" {
+  description = "Enable the OTLP/gRPC receiver (port 4317) to ingest OpenTelemetry traces and metrics"
+  type        = bool
+  default     = false
+}
+
+variable "enable_otlp_http" {
+  description = "Enable the OTLP/HTTP receiver (port 4318) to ingest OpenTelemetry traces and metrics"
+  type        = bool
+  default     = false
+}
+
+variable "enable_prometheus_scrape" {
+  description = "Enable Prometheus autodiscovery to scrape pods and services exposing Prometheus metrics"
+  type        = bool
+  default     = false
+}
+
 variable "enable_sbom" {
-  description = "Enable Software Bill of Materials (SBOM)"
+  description = "Enable Software Bill of Materials (SBOM) for container image vulnerability scanning"
   type        = bool
   default     = true
+}
+
+variable "enable_sbom_enrichment_usage" {
+  description = "Enable SBOM enrichment with runtime package-in-use detection (requires system-probe for eBPF-based file access tracking)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_sbom_host" {
+  description = "Enable SBOM collection for host packages"
+  type        = bool
+  default     = false
+}
+
+variable "enable_service_discovery" {
+  description = "Enable the service discovery check"
+  type        = bool
+  default     = false
+}
+
+variable "enable_tcp_queue_length" {
+  description = "Enable the TCP queue length eBPF-based check"
+  type        = bool
+  default     = false
 }
 
 variable "enable_usm" {
@@ -210,7 +306,7 @@ variable "node_agent_requests_memory" {
 variable "node_agent_tag" {
   description = "Tag for the Datadog node agent image"
   type        = string
-  default     = "7.76.2"
+  default     = "7.78.1"
 }
 
 variable "node_agent_tolerations" {

--- a/regional/manifests/variables.tofu
+++ b/regional/manifests/variables.tofu
@@ -59,35 +59,40 @@ variable "cluster_prefix" {
 
 variable "enable_apm" {
   description = <<EOF
-    Enable Application Performance Monitoring (APM)
-    Cost: $36.00 per host monthly
+    Enable Application Performance Monitoring (APM).
+    Cost: $31/host/month (annual) with Infrastructure Monitoring; $36/host/month standalone.
+    On-demand: $48/host/month with Infra, $36 standalone.
+    Includes Universal Service Monitoring (USM) on the same host at no additional cost.
+    Allotments: 150 GB ingested spans and 1M indexed spans per APM host per month.
     EOF
   type        = bool
   default     = false
 }
 
 variable "enable_apm_instrumentation" {
-  description = "Enable Application Performance Monitoring (APM) Single-Step instrumentation"
+  description = "Enable Application Performance Monitoring (APM) Single-Step instrumentation. No additional cost beyond the APM license; requires enable_apm = true."
   type        = bool
   default     = false
 }
 
 variable "enable_asm_iast" {
-  description = "Enable Interactive Application Security Testing (IAST)"
+  description = "Enable Interactive Application Security Testing (IAST). Included as part of App and API Protection (enable_asm_threats); no separate cost."
   type        = bool
   default     = false
 }
 
 variable "enable_asm_sca" {
-  description = "Enable Software Composition Analysis (SCA)"
+  description = "Enable Software Composition Analysis (SCA). Part of the App and API Protection suite; no separate cost beyond enable_asm_threats."
   type        = bool
   default     = false
 }
 
 variable "enable_asm_threats" {
   description = <<EOF
-    Enable ASM App & API Protection
-    Cost: $36.00 per host monthly
+    Enable App and API Protection (threat detection and blocking via in-app WAF).
+    Cost: $31/host/month (annual) with Infrastructure Monitoring; $36/host/month standalone.
+    On-demand: $36/host/month. Requires Infrastructure Monitoring.
+    Includes IAST (enable_asm_iast) and SCA (enable_asm_sca) at no extra cost.
     EOF
   type        = bool
   default     = false
@@ -112,15 +117,18 @@ variable "enable_cluster_checks_runners" {
 }
 
 variable "enable_container_collect_all" {
-  description = "Enable log collection for all containers"
+  description = "Enable log collection for all containers. Log ingestion and indexing are billed separately under Log Management; see https://www.datadoghq.com/pricing/?product=log-management."
   type        = bool
   default     = true
 }
 
 variable "enable_cspm" {
   description = <<EOF
-    Enable Cloud Security Posture Management (CSPM)
-    Cost: $12.00 per host monthly
+    Enable Cloud Security Posture Management (CSPM) via CSM Pro.
+    CSM Pro includes CSPM, KSPM, vulnerability management for containers and hosts, and CIEM.
+    Cost: $10/host/month (annual); $12/host/month on-demand. Standalone — no Infrastructure Monitoring required.
+    CSM Enterprise (adds Workload Protection + file integrity monitoring): $25/host/month (annual), requires Infra Enterprise.
+    Also available bundled in DevSecOps Pro ($22/host) or DevSecOps Enterprise ($34/host).
     EOF
   type        = bool
   default     = false
@@ -128,15 +136,16 @@ variable "enable_cspm" {
 
 variable "enable_cws" {
   description = <<EOF
-    Enable Cloud Workload Security (CWS)
-    Cost: $36.00 per host monthly
+    Enable Cloud Workload Security (CWS), now named Workload Protection — runtime threat detection via eBPF.
+    Standalone cost: $15/host/month (annual); $18/host/month on-demand. 4 containers allotted per host.
+    Also included in CSM Enterprise ($25/host/month) and DevSecOps Enterprise ($34/host/month).
     EOF
   type        = bool
   default     = false
 }
 
 variable "enable_cws_network_detection" {
-  description = "Enable Cloud Workload Security (CWS) network detections"
+  description = "Enable Cloud Workload Security (CWS) network detections. Requires enable_cws = true; no additional cost beyond the CWS/Workload Protection license."
   type        = bool
   default     = false
 }
@@ -166,19 +175,23 @@ variable "enable_jmx" {
 }
 
 variable "enable_live_process_collection" {
-  description = "Enable live process monitoring (process details visible in Datadog)"
+  description = "Enable live process monitoring (process details visible in Datadog). Included in Infrastructure Enterprise ($23/host/month annual); not available on Infrastructure Pro ($15/host/month). No separate SKU cost."
   type        = bool
   default     = false
 }
 
 variable "enable_log_collection" {
-  description = "Enable log collection"
+  description = "Enable log collection from the node agent. Log ingestion and indexing are billed separately under Log Management; see https://www.datadoghq.com/pricing/?product=log-management."
   type        = bool
   default     = true
 }
 
 variable "enable_npm" {
-  description = "Enable Network Performance Monitoring (NPM)"
+  description = <<EOF
+    Enable Cloud Network Monitoring (CNM/NPM) — host-level network traffic visibility using eBPF.
+    Cost: $5/host/month (annual); $7.20/host/month on-demand.
+    Requires Infrastructure Pro or Enterprise on every monitored host.
+    EOF
   type        = bool
   default     = true
 }
@@ -214,25 +227,25 @@ variable "enable_otlp_http" {
 }
 
 variable "enable_prometheus_scrape" {
-  description = "Enable Prometheus autodiscovery to scrape pods and services exposing Prometheus metrics"
+  description = "Enable Prometheus autodiscovery to scrape pods and services exposing Prometheus metrics. Scraped metrics count as custom metrics; Infrastructure Pro allots 100 custom metrics/host, Enterprise allots 200/host. Additional custom metrics cost ~$1/100 metrics/month."
   type        = bool
   default     = false
 }
 
 variable "enable_sbom" {
-  description = "Enable Software Bill of Materials (SBOM) for container image vulnerability scanning"
+  description = "Enable Software Bill of Materials (SBOM) for container image vulnerability scanning. Container vulnerability management is included in CSM Pro ($10/host/month annual) and CSM Enterprise ($25/host/month annual)."
   type        = bool
   default     = true
 }
 
 variable "enable_sbom_enrichment_usage" {
-  description = "Enable SBOM enrichment with runtime package-in-use detection (requires system-probe for eBPF-based file access tracking)"
+  description = "Enable SBOM enrichment with runtime package-in-use detection (requires system-probe for eBPF-based file access tracking). No additional cost beyond the CSM Pro/Enterprise license that covers vulnerability management."
   type        = bool
   default     = false
 }
 
 variable "enable_sbom_host" {
-  description = "Enable SBOM collection for host packages"
+  description = "Enable SBOM collection for host packages (OS-level package inventory). Included in CSM Pro ($10/host/month annual) and CSM Enterprise ($25/host/month annual) vulnerability management."
   type        = bool
   default     = false
 }
@@ -250,7 +263,11 @@ variable "enable_tcp_queue_length" {
 }
 
 variable "enable_usm" {
-  description = "Enable Universal Service Monitoring (USM)"
+  description = <<EOF
+    Enable Universal Service Monitoring (USM) — automatic service discovery and RED metrics via eBPF, no code changes required.
+    Cost: $9/host/month (annual); $13/host/month on-demand. Requires Infrastructure Monitoring.
+    Free on hosts where APM is already purchased (APM includes USM at no additional cost).
+    EOF
   type        = bool
   default     = true
 }

--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -39,7 +39,7 @@ variable "limits_memory" {
 variable "operator_version" {
   description = "The version of the Datadog Operator to install"
   type        = string
-  default     = "2.18.1"
+  default     = "2.21.1"
 }
 
 variable "requests_cpu" {

--- a/tests/fixtures/default/regional/manifests/main.tofu
+++ b/tests/fixtures/default/regional/manifests/main.tofu
@@ -19,6 +19,7 @@ module "test_manifests" {
   app_key        = "mock"
   cluster_prefix = "mock"
 
+  enable_apm                 = true
   enable_apm_instrumentation = true
 
   node_agent_tolerations = [


### PR DESCRIPTION
## Summary

Expands the module to support all current Datadog Agent features and bumps versions to latest stable releases.

### Version updates

| Component | Before | After |
|---|---|---|
| Operator helm chart | `2.18.1` | `2.21.1` |
| Node agent image | `7.76.2` | `7.78.1` |
| Cluster agent image | _(not pinned)_ | `7.78.1` |

### New feature toggles (all default `false`)

| Variable | Description |
|---|---|
| `enable_autoscaling_cluster` | Cluster autoscaling product (requires Cluster Agent 7.74.0+) |
| `enable_autoscaling_workload` | Workload autoscaling (was hardcoded `true`, now a variable defaulting `true`) |
| `enable_cluster_checks_runners` | Dedicated CCR pods to offload cluster-level checks |
| `enable_ebpf_check` | eBPF kernel-level observability check |
| `enable_helm_check` | Monitor Helm releases in the cluster |
| `enable_live_process_collection` | Live process monitoring |
| `enable_oom_kill` | OOMKill eBPF-based check |
| `enable_otel_collector` | Embedded OpenTelemetry collector |
| `enable_otlp_grpc` | OTLP/gRPC receiver (port 4317) |
| `enable_otlp_http` | OTLP/HTTP receiver (port 4318) |
| `enable_prometheus_scrape` | Prometheus autodiscovery |
| `enable_sbom_host` | Host package SBOM collection |
| `enable_sbom_enrichment_usage` | Runtime package-in-use SBOM enrichment (requires system-probe) |
| `enable_service_discovery` | Service discovery check |
| `enable_tcp_queue_length` | TCP queue length eBPF-based check |

### Other fixes

- **Added `cluster_agent_tag`** — cluster agent image was not pinned; its version label also incorrectly referenced `node_agent_tag`
- **Wired up cluster agent resource variables** — `cluster_agent_limits_*` and `cluster_agent_requests_*` were defined but never applied to the override block
- **Feature dependency checks** — `check` blocks fail with a clear message if:
  - `enable_apm_instrumentation` is set without `enable_apm`
  - `enable_cws_network_detection` is set without `enable_cws`
  - `enable_sbom_enrichment_usage` is set without `enable_sbom`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 16+ toggles to control agent capabilities (autoscaling cluster/workload, cluster checks runners, eBPF/oom/tcp checks, Helm check, live process, SBOM enrichment/host SBOM, OpenTelemetry/OTLP, Prometheus scraping, service discovery).
  * Added validation rules enforcing APM instrumentation, CWS network detection, and SBOM enrichment dependencies.

* **Updates**
  * Introduced separate cluster agent image tag and bumped agent/operator defaults to 7.78.1 / 2.21.1; made cluster-agent CPU/memory configurable.
  * Updated multiple feature descriptions for packaging, pricing, and requirements.

* **Documentation**
  * Expanded maintenance and pricing guidance for feature variables.

* **Tests**
  * Test fixture updated to enable APM at module level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->