### PR TITLE
Declare module required providers

### DIFF
--- a/regional/manifests/providers.tofu
+++ b/regional/manifests/providers.tofu
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/regional/providers.tofu
+++ b/regional/providers.tofu
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+
+    # Helm Provider
+    # https://search.opentofu.org/provider/hashicorp/helm/latest/docs
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
## What
- Add required_providers declarations for the regional Helm/operator module and manifests module.
- Declare only providers used by each module based on resource usage.

## Why
Consumers passing explicit per-cluster provider instances avoid OpenTofu undefined-provider warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added and standardized infrastructure provider requirements for Kubernetes and Helm.
  * Improved environment setup consistency for deployments that use OpenTofu/Terraform-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->