### PR TITLE
Remove unused agent_namespace variable

### DIFF
--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -1,12 +1,6 @@
 # Input Variables
 # https://opentofu.org/docs/language/values/variables
 
-variable "agent_namespace" {
-  description = "Namespace for the Datadog Agent"
-  type        = string
-  default     = "datadog"
-}
-
 variable "api_key" {
   description = "Datadog API key"
   type        = string


### PR DESCRIPTION
Removes `variable "agent_namespace"` from `regional/variables.tofu`. The variable was defined but never referenced anywhere in the module. The namespace is a platform invariant hardcoded directly in `main.tofu`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the configurable agent namespace setting from regional deployment configuration.
  * Regional deployments will no longer expose this input option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->