### PR TITLE
Update Datadog operator to 2.24.0 and agent to 7.81.1

### DIFF
--- a/regional/manifests/variables.tofu
+++ b/regional/manifests/variables.tofu
@@ -49,7 +49,7 @@ variable "cluster_agent_requests_memory" {
 variable "cluster_agent_tag" {
   description = "Tag for the Datadog cluster agent image"
   type        = string
-  default     = "7.78.1"
+  default     = "7.81.1"
 }
 
 variable "cluster_prefix" {
@@ -243,7 +243,7 @@ variable "node_agent_requests_memory" {
 variable "node_agent_tag" {
   description = "Tag for the Datadog node agent image"
   type        = string
-  default     = "7.78.1"
+  default     = "7.81.1"
 }
 
 variable "node_agent_tolerations" {

--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -33,7 +33,7 @@ variable "limits_memory" {
 variable "operator_version" {
   description = "The version of the Datadog Operator to install"
   type        = string
-  default     = "2.21.1"
+  default     = "2.24.0"
 }
 
 variable "requests_cpu" {


### PR DESCRIPTION
Update upstream component versions:
- `operator_version`: 2.21.1 → 2.24.0
- `node_agent_tag`: 7.78.1 → 7.81.1
- `cluster_agent_tag`: 7.78.1 → 7.81.1