### PR TITLE
Update pt-arche-core-helpers to v0.3.3

### DIFF
--- a/shared/helpers.tofu
+++ b/shared/helpers.tofu
@@ -2,5 +2,5 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=7e9435f875ac91ac8538385fe8b4554dd068673e" # v0.3.2
+  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=7712df4d2b0a6333ff74ae7b626c593033019082" # v0.3.3
 }


### PR DESCRIPTION
Bumps the pt-arche-core-helpers SHA pin to v0.3.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integrated helper module to version 0.3.3.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->